### PR TITLE
paludis support for deselect and virtual remerge

### DIFF
--- a/perl-cleaner
+++ b/perl-cleaner
@@ -13,7 +13,7 @@ PMS_PRETEND=( "-p" "-p" "--no-execute" )
 PMS_INSTALLED_COMMAND=( "qlist -IC" "" "cave print-packages --repository installed" )
 PMS_DESELECT_COMMAND=( "emerge --deselect" "" "cave update-world --remove" )
 PMS_SELECT_COMMAND=( "emerge --noreplace" "" "cave update-world" )
-PMS_UPGRADE_COMMAND=( "emerge -u1" "" "cave resolve -x1z" )
+PMS_UPGRADE_COMMAND=( "emerge -u1" "" "cave resolve -x1zU perl-core/*" )
 
 CUSTOM_PMS_COMMAND=""
 

--- a/perl-cleaner
+++ b/perl-cleaner
@@ -10,10 +10,10 @@ PMS_COMMAND=( "emerge" "pmerge" "cave resolve" )
 PMS_OPTIONS=( "-v1 --backtrack=100" "-Do" "-x1z" )
 PMS_PRETEND=( "-p" "-p" "--no-execute" )
 
-PMS_INSTALLED_COMMAND=( "qlist -IC" "" "" )
-PMS_DESELECT_COMMAND=( "emerge --deselect" "" "" )
-PMS_SELECT_COMMAND=( "emerge --noreplace" "" "" )
-PMS_UPGRADE_COMMAND=( "emerge -u1" "" "" )
+PMS_INSTALLED_COMMAND=( "qlist -IC" "" "cave print-packages --repository installed" )
+PMS_DESELECT_COMMAND=( "emerge --deselect" "" "cave update-world --remove" )
+PMS_SELECT_COMMAND=( "emerge --noreplace" "" "cave update-world" )
+PMS_UPGRADE_COMMAND=( "emerge -u1" "" "cave resolve -x1z" )
 
 CUSTOM_PMS_COMMAND=""
 
@@ -81,11 +81,11 @@ outdated_path(){
 # this function removes all perl-core/* entries from your world file
 # you should use virtual/perl-* there instead
 deselect_perlcore() {
-    if [[ ${PMS_COMMAND[${PMS_INDEX}]} == emerge ]] ; then
+    if [[ ${PMS_COMMAND[${PMS_INDEX}]} != pkgcore ]] ; then
 
         local perlcorelist
 	local perlcorelistoneline
-	perlcorelist=$( ${PMS_INSTALLED_COMMAND[${PMS_INDEX}]} 'perl-core/*' )
+	perlcorelist=$( ${PMS_INSTALLED_COMMAND[${PMS_INDEX}]} | grep '^perl-core/' )
 	perlcorelistoneline=$(echo ${perlcorelist} | tr '\n' ' ' )
 
 	veinfo 2 "Installed perl-core packages: ${perlcorelistoneline}"
@@ -106,18 +106,18 @@ deselect_perlcore() {
         veinfo 0 "You should deselect all perl-core packages in your configuration before running"
         veinfo 0 "perl-cleaner. They must only be installed as dependency of Perl virtuals."
         veinfo 0 "This is done automatically for portage, but not implemented yet"
-        veinfo 0 "for paludis and pkgcore. If perl-cleaner fails - you've been warned."
+        veinfo 0 "for pkgcore. If perl-cleaner fails - you've been warned."
         vecho 0
     fi
 }
 
 # this function updates all Perl virtuals (deep)
 update_virtuals() {
-    if [[ ${PMS_COMMAND[${PMS_INDEX}]} == emerge ]] ; then
+    if [[ ${PMS_COMMAND[${PMS_INDEX}]} != pkgcore ]] ; then
 
         local perlvirtuallist
 	local perlvirtuallistoneline
-	perlvirtuallist=$( ${PMS_INSTALLED_COMMAND[${PMS_INDEX}]} 'virtual/perl-*' )
+	perlvirtuallist=$( ${PMS_INSTALLED_COMMAND[${PMS_INDEX}]} | grep '^virtual/perl-' )
 	perlvirtuallistoneline=$(echo ${perlvirtuallist} | tr '\n' ' ' )
 
 	veinfo 2 "Installed Perl virtuals: ${perlvirtuallistoneline}"
@@ -137,7 +137,7 @@ update_virtuals() {
         vecho 0
         veinfo 0 "You should update all the Perl virtuals and their dependencies before running"
         veinfo 0 "perl-cleaner. This is done automatically for portage, but not implemented yet"
-        veinfo 0 "for paludis and pkgcore. If perl-cleaner fails - you've been warned."
+        veinfo 0 "for pkgcore. If perl-cleaner fails - you've been warned."
         vecho 0
     fi
 }


### PR DESCRIPTION
added support for paludis for automatic deselection and remerging of
virtual packages. cave print-packages doesn't accept any parameters
besides a repository and a category (which isn't specific enough for the
virtuals), thus I replaced the paramater to qlist with a grep over the
result, which works for portage and paludis
