### PR TITLE
respect PACKAGE_MANAGER env variable (see bug #434520)

### DIFF
--- a/perl-cleaner
+++ b/perl-cleaner
@@ -472,21 +472,6 @@ while [[ -n "$1" ]] ; do
         -P|--package-manager)
             shift
             PACKAGE_MANAGER="$1"
-            case "${PACKAGE_MANAGER}" in
-                portage|pkgcore|paludis)
-                    ;;
-                *)
-                    echo "unrecognised package manager selected. please select between ${SUPPORTED_PMS}"
-                    exit
-                    ;;
-            esac
-
-            # PMS_INDEX is used to select the right commands and options for the selected package manager
-            PMS_INDEX=0
-            for PM in ${SUPPORTED_PMS} ; do
-                [[ ${PM} == ${PACKAGE_MANAGER} ]] && break
-                PMS_INDEX=$((${PMS_INDEX} + 1))
-            done
             ;;
         --package-manager-command)
             shift
@@ -550,6 +535,25 @@ while [[ -n "$1" ]] ; do
             ;;
     esac
     shift
+done
+
+# set portage as default if no PM is given
+PACKAGE_MANAGER=${PACKAGE_MANAGER:-portage}
+
+case "${PACKAGE_MANAGER}" in
+    portage|pkgcore|paludis)
+        ;;
+    *)
+        echo "unrecognised package manager selected. please select between ${SUPPORTED_PMS}"
+        exit
+        ;;
+esac
+
+# PMS_INDEX is used to select the right commands and options for the selected package manager
+PMS_INDEX=0
+for PM in ${SUPPORTED_PMS} ; do
+    [[ ${PM} == ${PACKAGE_MANAGER} ]] && break
+    PMS_INDEX=$((${PMS_INDEX} + 1))
 done
 
 if [[ ! -z "${ADDITIONAL_OPTIONS}" ]] ; then


### PR DESCRIPTION
All the code is there, but not used if -P is not set. Moving the code setting PMS_INDEX behind argument parsing fixes that.
Also setting PACKAGE_MANAGER to portage if it is not specified.
