### PR TITLE
Add --selective-n to emerge options.

### DIFF
--- a/perl-cleaner
+++ b/perl-cleaner
@@ -3,11 +3,11 @@
 # Copyright 2005-2014 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
-PERL_CLEANER_VERSION="2.20"
+PERL_CLEANER_VERSION="2.21"
 
 SUPPORTED_PMS="portage pkgcore paludis"
 PMS_COMMAND=( "emerge" "pmerge" "cave resolve" )
-PMS_OPTIONS=( "-v1 --backtrack=200" "-Do" "-x1z" )
+PMS_OPTIONS=( "-v1 --backtrack=200 --selective=n" "-Do" "-x1z" )
 PMS_PRETEND=( "-p" "-p" "--no-execute" )
 
 PMS_INSTALLED_COMMAND=( "qlist -IC" "" "" )


### PR DESCRIPTION
Submitting this as a pull request as I would like review and feedback about the change.  The change itself is minor.

When running perl-cleaner, if a user has --changed-use or --newuse in
EMERGE_DEFAULT_OPTS, emerge will not reinstall a package. Adding
--selective=n will cause emerge to reinstall packages even if those
options are present.

This ensures that perl-cleaner reinstalls everything, so that everything
is installed to the correct path.
