### PR TITLE
compute simplified version with perl instead of fixed list

### DIFF
--- a/perl-cleaner
+++ b/perl-cleaner
@@ -572,11 +572,8 @@ fi
 # version=
 eval $(perl -V:version )
 veinfo 3 "Installed perl version: ${version}"
-[[ ${version} == 5.32.* ]] && version=5.32 && veinfo 3 "Simplified perl version: ${version}"
-[[ ${version} == 5.33.* ]] && version=5.33 && veinfo 3 "Simplified perl version: ${version}"
-[[ ${version} == 5.34.* ]] && version=5.34 && veinfo 3 "Simplified perl version: ${version}"
-[[ ${version} == 5.35.* ]] && version=5.35 && veinfo 3 "Simplified perl version: ${version}"
-[[ ${version} == 5.36.* ]] && version=5.36 && veinfo 3 "Simplified perl version: ${version}"
+version=$(perl -le 'print $^V =~ /(\d+\.\d+)/')
+veinfo 3 "Simplified perl version: ${version}"
 # and after 5.36 we can do this unconditionally
 # archname=
 eval $(perl -V:archname )


### PR DESCRIPTION
This script doesn't currently work properly with 5.38 (--modules will rebuild everything due to not identifying the current version) because a line has not been added to convert 5.38.* to 5.38. This change uses a simple perl regex match to get the simplified version instead so it will automatically recognize any version.